### PR TITLE
added ReactiveCouchbase repository to build.sbt

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -5,3 +5,5 @@ version := "1.0"
 scalaVersion := "2.11.1"
 
 libraryDependencies += "org.reactivecouchbase" %% "reactivecouchbase-core" % "0.4-SNAPSHOT"
+
+resolvers += "ReactiveCouchbase repository" at "https://raw.github.com/ReactiveCouchbase/repository/master/snapshots"


### PR DESCRIPTION
Without the repo, the dependency can not be found and the project does not compile.
